### PR TITLE
Automatically authorize if authorization exists and is valid

### DIFF
--- a/server/src/OAuth2Demo/Server/Controllers/Authorize.php
+++ b/server/src/OAuth2Demo/Server/Controllers/Authorize.php
@@ -37,11 +37,21 @@ class Authorize
             $error = $response->getParameter('error_description');
         }
 
+        /** @var User $user */
+        $user = $app['security']->getToken()->getUser();
+
+        $client_id = $app['request']->query->get('client_id');
         $scope = $server->getAuthorizeController()->getScope();
+
+        if ($app['storage']->getExistingAccessToken($client_id, $user->getUsername(), $scope)) {
+            $app['request']->query->set('authorize', true);
+
+            return $this->authorizeSubmit($app);
+        }
 
         // dispaly the "do you want to authorize?" form
         return $app['twig']->render('authorize.twig', [
-            'client_id' => $app['request']->query->get('client_id'),
+            'client_id' => $client_id,
             'scope'     => $scope,
             'error'     => $error,
         ]);

--- a/server/src/OAuth2Demo/Server/Server.php
+++ b/server/src/OAuth2Demo/Server/Server.php
@@ -112,7 +112,7 @@ class Server implements ControllerProviderInterface
         $stmt->execute(array(
             'client_id'     => 'TopCluck',
             'client_secret' => '2e2dfd645da38940b1ff694733cc6be6',
-            'scope'         => 'eggs-collect profile',
+            'scope'         => 'eggs-count profile',
         ));
 
         // create a dummy user

--- a/server/src/OAuth2Demo/Server/Storage/Pdo.php
+++ b/server/src/OAuth2Demo/Server/Storage/Pdo.php
@@ -101,4 +101,15 @@ class Pdo extends OAuth2Pdo
 
         return $userInfo['username'];
     }
+
+    public function getExistingAccessToken($client_id, $user_id, $scope)
+    {
+        $stmt = $this->db->prepare(sprintf('SELECT * from %s where client_id=:client_id AND user_id=:user_id AND scope=:scope AND expires > :now', $this->config['access_token_table']));
+
+        $now = date('Y-m-d H:i:s', strtotime('+30 seconds'));
+
+        $stmt->execute(compact('client_id', 'user_id', 'scope', 'now'));
+
+        return $stmt->fetch();
+    }
 }


### PR DESCRIPTION
Does not prompt user to reauthorize if a valid token for the same user/client/scope exists

A re-open of #35 to trigger (hopefully) Travis
