### PR TITLE
Double forward slash causes error on Windows

### DIFF
--- a/client/data/rebuild_db.php
+++ b/client/data/rebuild_db.php
@@ -16,7 +16,7 @@ if (!is_writable(__DIR__)) {
 }
 
 // rebuild the DB
-$db = new PDO(sprintf('sqlite://%s', $dbfile));
+$db = new PDO(sprintf('sqlite:%s', $dbfile));
 $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 $db->exec('CREATE TABLE users (
     email TEXT PRIMARY KEY ASC,


### PR DESCRIPTION
the sqlite:// causes an error in windows. Removing the double forward slash fixes the problem since the correct DSN is only sqlite:
